### PR TITLE
Update the Maven javafx-dataviewer version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<dependency>
 			<groupId>charts</groupId>
 			<artifactId>javafx-dataviewer</artifactId>
-			<version>1.0.3</version>
+			<version>1.0.4</version>
 		</dependency>
 
 		<!-- Logging Logback -->


### PR DESCRIPTION
The  javafx-dataviewer version does not match [javafx-dataviewer](https://github.com/jasrodis/javafx-dataviewer) and therefore `mvn clean compile` steps fails.